### PR TITLE
[Major package refactor] separate transform, analyze, failures and app

### DIFF
--- a/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/BUILD.bazel
+++ b/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/BUILD.bazel
@@ -1,0 +1,12 @@
+package(default_visibility = ["//visibility:public"])
+
+sources()
+scala_library(
+    name = "analyze",
+    srcs = [
+        ":sources",
+    ],
+    deps = [
+        "//migrator/bazel-migrator-model/src/main/java/com/wix/bazel/migrator/model:model",
+    ]
+)

--- a/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/Code.scala
+++ b/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/Code.scala
@@ -1,0 +1,7 @@
+package com.wix.bazel.migrator.analyze
+
+import com.wix.bazel.migrator.model.TestType
+
+private [migrator] case class Code(codePath: CodePath, dependencies: List[Dependency] = Nil, externalSourceDependencies: Set[String] = Set.empty) {
+  def testType: TestType = TestType.from(codePath.filePath)
+}

--- a/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/CodePath.scala
+++ b/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/CodePath.scala
@@ -1,8 +1,9 @@
-package com.wix.bazel.migrator.transform
+package com.wix.bazel.migrator.analyze
 
 import com.wix.bazel.migrator.model.SourceModule
+
 //TODO replace module and relativeSourceDirPathFromModuleRoot with SourceCodeDirPath
-private[transform] case class CodePath(module: SourceModule,
+private[migrator] case class CodePath(module: SourceModule,
                                        relativeSourceDirPathFromModuleRoot: String,
                                        filePath: String) {
   def extension: String = filePath.split('.').last

--- a/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/Dependency.scala
+++ b/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/Dependency.scala
@@ -1,0 +1,3 @@
+package com.wix.bazel.migrator.analyze
+
+private [migrator] case class Dependency(codePath: CodePath, isCompileDependency: Boolean)

--- a/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/DependencyAnalyzer.scala
+++ b/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/DependencyAnalyzer.scala
@@ -1,7 +1,7 @@
-package com.wix.bazel.migrator.transform
+package com.wix.bazel.migrator.analyze
 
 import com.wix.bazel.migrator.model.SourceModule
 
-private[transform] trait DependencyAnalyzer {
+private[migrator] trait DependencyAnalyzer {
   def allCodeForModule(module: SourceModule): List[Code]
 }

--- a/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/BUILD.bazel
+++ b/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/BUILD.bazel
@@ -13,6 +13,7 @@ scala_library(
         "//migrator/bazel-migrator-model/src/main/java/com/wix/bazel/migrator/model",
         "//models/maven-model/src/main/scala/com/wixpress/build/maven",
         "@org_jgrapht_jgrapht_core",
+        "//migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze:analyze",
     ],
 )
 

--- a/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/Code.scala
+++ b/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/Code.scala
@@ -1,7 +1,0 @@
-package com.wix.bazel.migrator.transform
-
-import com.wix.bazel.migrator.model.TestType
-
-private[transform] case class Code(codePath: CodePath, dependencies: List[Dependency] = Nil, externalSourceDependencies: Set[String] = Set.empty) {
-  def testType: TestType = TestType.from(codePath.filePath)
-}

--- a/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/CodeAnalysisTransformer.scala
+++ b/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/CodeAnalysisTransformer.scala
@@ -1,5 +1,6 @@
 package com.wix.bazel.migrator.transform
 
+import com.wix.bazel.migrator.analyze.{Code, DependencyAnalyzer}
 import com.wix.bazel.migrator.model
 import com.wix.bazel.migrator.model.Target.TargetDependency
 import com.wix.bazel.migrator.model.{Package, SourceModule, Target}

--- a/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/Dependency.scala
+++ b/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/Dependency.scala
@@ -1,3 +1,0 @@
-package com.wix.bazel.migrator.transform
-
-private[transform] case class Dependency(codePath: CodePath, isCompileDependency: Boolean)

--- a/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/GraphAndCodes.scala
+++ b/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/GraphAndCodes.scala
@@ -1,5 +1,6 @@
 package com.wix.bazel.migrator.transform
 
+import com.wix.bazel.migrator.analyze.Code
 import com.wix.bazel.migrator.transform.GraphSupport._
 
 private[transform] case class GraphAndCodes(graph: CodeGraph, keyToCodes: Map[Vertex, Set[Code]])

--- a/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/GraphSupport.scala
+++ b/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/GraphSupport.scala
@@ -1,5 +1,6 @@
 package com.wix.bazel.migrator.transform
 
+import com.wix.bazel.migrator.analyze.Code
 import org.jgrapht
 import org.jgrapht.graph.DefaultDirectedGraph
 

--- a/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/ResourceKey.scala
+++ b/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/ResourceKey.scala
@@ -2,6 +2,7 @@ package com.wix.bazel.migrator.transform
 
 import java.nio.file.Paths
 
+import com.wix.bazel.migrator.analyze.CodePath
 import com.wix.bazel.migrator.model.Target.TargetDependency
 import com.wix.bazel.migrator.model._
 import com.wix.bazel.migrator.transform.GraphSupport.CodesMap

--- a/migrator/bazel-migrator/src/test/java/com/wix/bazel/migrator/transform/FakeDependencyAnalyzer.scala
+++ b/migrator/bazel-migrator/src/test/java/com/wix/bazel/migrator/transform/FakeDependencyAnalyzer.scala
@@ -1,5 +1,6 @@
 package com.wix.bazel.migrator.transform
 
+import com.wix.bazel.migrator.analyze.{Code, DependencyAnalyzer}
 import com.wix.bazel.migrator.model.SourceModule
 import com.wix.bazel.migrator.transform.makers.Repo
 

--- a/migrator/bazel-migrator/src/test/java/com/wix/bazel/migrator/transform/makers/BUILD.bazel
+++ b/migrator/bazel-migrator/src/test/java/com/wix/bazel/migrator/transform/makers/BUILD.bazel
@@ -14,6 +14,7 @@ scala_library(
         "//migrator/bazel-migrator-model/src/main/java/com/wix/bazel/migrator/model",
         "//migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform",
         "//models/maven-model/src/main/scala/com/wixpress/build/maven",
+        "//migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze:analyze",
         "@junit_junit",
     ],
 )

--- a/migrator/bazel-migrator/src/test/java/com/wix/bazel/migrator/transform/makers/CodeMaker.scala
+++ b/migrator/bazel-migrator/src/test/java/com/wix/bazel/migrator/transform/makers/CodeMaker.scala
@@ -1,9 +1,10 @@
 package com.wix.bazel.migrator.transform.makers
 
+import com.wix.bazel.migrator.analyze
+import com.wix.bazel.migrator.analyze.{Code, Dependency}
 import com.wix.bazel.migrator.model.SourceModule
 import com.wix.bazel.migrator.model.makers.ModuleMaker.aModule
 import com.wix.bazel.migrator.transform.makers.CodePathMaker.sourceCodePath
-import com.wix.bazel.migrator.transform.{Code, Dependency}
 
 object CodeMaker {
 
@@ -12,7 +13,7 @@ object CodeMaker {
            relativeSourceDirPathFromModuleRoot: String = "src/main/java",
            dependencies: List[Dependency] = Nil,
            externalDependencies: Set[String] = Set.empty): Code =
-    Code(sourceCodePath(filePath, module, relativeSourceDirPathFromModuleRoot), dependencies, externalDependencies)
+    analyze.Code(sourceCodePath(filePath, module, relativeSourceDirPathFromModuleRoot), dependencies, externalDependencies)
 
   def testCode(filePath: String): Code = code(filePath, relativeSourceDirPathFromModuleRoot = "src/test/java", externalDependencies = Set.empty)
 }

--- a/migrator/bazel-migrator/src/test/java/com/wix/bazel/migrator/transform/makers/CodePathMaker.scala
+++ b/migrator/bazel-migrator/src/test/java/com/wix/bazel/migrator/transform/makers/CodePathMaker.scala
@@ -1,12 +1,13 @@
 package com.wix.bazel.migrator.transform.makers
 
+import com.wix.bazel.migrator.analyze
+import com.wix.bazel.migrator.analyze.CodePath
 import com.wix.bazel.migrator.model.SourceModule
-import com.wix.bazel.migrator.transform.CodePath
 
 object CodePathMaker {
 
   def sourceCodePath(filePath: String,
            module: SourceModule,
            relativeSourceDirPathFromModuleRoot: String): CodePath =
-    CodePath(module, relativeSourceDirPathFromModuleRoot, filePath)
+    analyze.CodePath(module, relativeSourceDirPathFromModuleRoot, filePath)
 }

--- a/migrator/bazel-migrator/src/test/java/com/wix/bazel/migrator/transform/makers/DependencyMaker.scala
+++ b/migrator/bazel-migrator/src/test/java/com/wix/bazel/migrator/transform/makers/DependencyMaker.scala
@@ -1,8 +1,8 @@
 package com.wix.bazel.migrator.transform.makers
 
+import com.wix.bazel.migrator.analyze.Dependency
 import com.wix.bazel.migrator.model.SourceModule
 import com.wix.bazel.migrator.model.makers.ModuleMaker.aModule
-import com.wix.bazel.migrator.transform.Dependency
 import com.wix.bazel.migrator.transform.makers.CodePathMaker.sourceCodePath
 
 object DependencyMaker {

--- a/migrator/bazel-migrator/src/test/java/com/wix/bazel/migrator/transform/makers/Repo.scala
+++ b/migrator/bazel-migrator/src/test/java/com/wix/bazel/migrator/transform/makers/Repo.scala
@@ -1,7 +1,7 @@
 package com.wix.bazel.migrator.transform.makers
 
+import com.wix.bazel.migrator.analyze.Code
 import com.wix.bazel.migrator.model.SourceModule
-import com.wix.bazel.migrator.transform.Code
 
 case class Repo(code: List[Code] = Nil) {
   def withCode(moreCode: Code) = Repo(moreCode +: code)

--- a/migrator/wix-bazel-migrator/BUILD.bazel
+++ b/migrator/wix-bazel-migrator/BUILD.bazel
@@ -43,9 +43,8 @@ filegroup(
 
 java_binary(
     name = "migrator_cli",
-    main_class = "com.wix.bazel.migrator.MigratorApplication",
+    main_class = "com.wix.bazel.migrator.app.MigratorApplication",
     runtime_deps = [
-        "//migrator/wix-bazel-migrator/src/main/java/com/wix:agg=bazel/migrator_bazel/migrator/transform_build/maven/analysis",
-        
+        "//migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app",
     ],
 )

--- a/migrator/wix-bazel-migrator/src/it/java/com/wix/bazel/migrator/BUILD.bazel
+++ b/migrator/wix-bazel-migrator/src/it/java/com/wix/bazel/migrator/BUILD.bazel
@@ -17,6 +17,7 @@ specs2_ite2e_test(
         "//migrator/wix-bazel-migrator:tests_dependencies",
         "//migrator/wix-bazel-migrator/src/it/java/com/wix/bazel/migrator/matchers",
         "//migrator/wix-bazel-migrator/src/main/java/com/wix:agg=bazel/migrator_bazel/migrator/transform_build/maven/analysis",
+        "//migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app",
         "@com_github_marschall_memoryfilesystem",
         "@com_github_pathikrit_better_files_2_12",
     ],

--- a/migrator/wix-bazel-migrator/src/it/java/com/wix/bazel/migrator/WriterIT.scala
+++ b/migrator/wix-bazel-migrator/src/it/java/com/wix/bazel/migrator/WriterIT.scala
@@ -1,5 +1,6 @@
 package com.wix.bazel.migrator
 
+import com.wix.bazel.migrator.app.{JavaWriter, ScalaWriter, Writer}
 import com.wix.bazel.migrator.model.CodePurpose.{Prod, Test}
 import com.wix.bazel.migrator.model.Target.{Jvm, ModuleDeps, TargetDependency}
 import com.wix.bazel.migrator.model.TestType.UT

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/BUILD.bazel
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/BUILD.bazel
@@ -30,7 +30,6 @@ scala_library(
         "//repo-analyzer/maven-repo-analyzer/src/main/java/com/wix/build/maven/analysis",
         "//repo-analyzer/maven-repo-analyzer/src/main/java/com/wix/build/zinc/analysis",
         "//workspaces-resolution-utils/src/main/scala/com/wixpress/build/bazel/workspaces",
-        "@com_codota_codota_sdk_java",
         "@com_fasterxml_jackson_core_jackson_annotations",
         "@com_fasterxml_jackson_core_jackson_core",
         "@com_fasterxml_jackson_core_jackson_databind",

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/BUILD.bazel
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/BUILD.bazel
@@ -1,0 +1,24 @@
+package(default_visibility = ["//visibility:public"])
+
+sources()
+scala_library(
+    name = "analyze",
+    srcs = [
+        ":sources",
+    ],
+    deps = [
+        "//migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze:analyze",
+        "//dependency-resolver/maven-dependency-resolver-api/src/main/scala/com/wixpress/build/maven:maven",
+        "@com_fasterxml_jackson_core_jackson_annotations",
+        "@com_fasterxml_jackson_core_jackson_core",
+        "@com_fasterxml_jackson_core_jackson_databind",
+        "@com_fasterxml_jackson_module_jackson_module_scala_2_12",
+        "@org_slf4j_slf4j_api",
+        "@com_codota_codota_sdk_java",
+        "//migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/utils:utils",
+        "//migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/overrides:overrides",
+        "//migrator/wix-bazel-migrator/src/main/java/com/wix:agg=bazel/migrator_bazel/migrator/transform_build/maven/analysis",
+        "//repo-analyzer/maven-repo-analyzer/src/main/java/com/wix/build/zinc/analysis:analysis",
+
+    ]
+)

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/CachingEagerEvaluatingCodotaDependencyAnalyzer.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/CachingEagerEvaluatingCodotaDependencyAnalyzer.scala
@@ -1,4 +1,4 @@
-package com.wix.bazel.migrator.transform
+package com.wix.bazel.migrator.analyze
 
 import java.nio.file.{Files, Path, Paths}
 import java.util

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/CodotaDependencyAnalyzer.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/CodotaDependencyAnalyzer.scala
@@ -8,16 +8,14 @@ import com.codota.service.model.DependencyInfo
 import com.codota.service.model.DependencyInfo.OptionalInternalDependency
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.wix.bazel.migrator.utils.Retry._
-import com.wix.bazel.migrator.analyze
 import com.wix.bazel.migrator.analyze.CodotaDependencyAnalyzer._
 import com.wix.bazel.migrator.model._
 import com.wix.bazel.migrator.overrides.GeneratedCodeOverridesReader
-import com.wix.bazel.migrator.transform.failures.{AnalyzeException, AnalyzeFailure, FailureMetadata}
 import com.wix.bazel.migrator.transform.failures.AnalyzeFailure.MissingAnalysisInCodota
 import com.wix.bazel.migrator.transform.failures.FailureMetadata.InternalDepMissingExtended
-import com.wix.bazel.migrator.transform.failures.{AnalyzeFailure, FailureMetadata}
+import com.wix.bazel.migrator.transform.failures.{AnalyzeException, AnalyzeFailure, FailureMetadata}
 import com.wix.bazel.migrator.utils.DependenciesDifferentiator
+import com.wix.bazel.migrator.utils.Retry._
 import com.wixpress.build.maven
 import com.wixpress.build.maven.{Coordinates, MavenScope}
 import org.slf4j.LoggerFactory
@@ -258,7 +256,7 @@ class CodotaDependencyAnalyzer(repoRoot: Path,
     findSourceModule(simplifiedDependency).right.flatMap {
       case Some(sourceModule) =>
         sourceDirEither(sourceModule, simplifiedDependency.filepath).right.map { sourceDir =>
-          Some(Dependency(analyze.CodePath(sourceModule, sourceDir, simplifiedDependency.filepath), isCompileDependency = true))
+          Some(Dependency(CodePath(sourceModule, sourceDir, simplifiedDependency.filepath), isCompileDependency = true))
         }
       case None =>
         Right(None)

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/CodotaDependencyAnalyzer.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/CodotaDependencyAnalyzer.scala
@@ -1,4 +1,4 @@
-package com.wix.bazel.migrator.transform
+package com.wix.bazel.migrator.analyze
 
 import java.nio.file.{Files, Path, Paths}
 
@@ -8,12 +8,15 @@ import com.codota.service.model.DependencyInfo
 import com.codota.service.model.DependencyInfo.OptionalInternalDependency
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.wix.bazel.migrator.Retry._
+import com.wix.bazel.migrator.utils.Retry._
+import com.wix.bazel.migrator.analyze
+import com.wix.bazel.migrator.analyze.CodotaDependencyAnalyzer._
 import com.wix.bazel.migrator.model._
 import com.wix.bazel.migrator.overrides.GeneratedCodeOverridesReader
-import com.wix.bazel.migrator.transform.AnalyzeFailure.MissingAnalysisInCodota
-import com.wix.bazel.migrator.transform.CodotaDependencyAnalyzer._
-import com.wix.bazel.migrator.transform.FailureMetadata.InternalDepMissingExtended
+import com.wix.bazel.migrator.transform.failures.{AnalyzeException, AnalyzeFailure, FailureMetadata}
+import com.wix.bazel.migrator.transform.failures.AnalyzeFailure.MissingAnalysisInCodota
+import com.wix.bazel.migrator.transform.failures.FailureMetadata.InternalDepMissingExtended
+import com.wix.bazel.migrator.transform.failures.{AnalyzeFailure, FailureMetadata}
 import com.wix.bazel.migrator.utils.DependenciesDifferentiator
 import com.wixpress.build.maven
 import com.wixpress.build.maven.{Coordinates, MavenScope}
@@ -255,7 +258,7 @@ class CodotaDependencyAnalyzer(repoRoot: Path,
     findSourceModule(simplifiedDependency).right.flatMap {
       case Some(sourceModule) =>
         sourceDirEither(sourceModule, simplifiedDependency.filepath).right.map { sourceDir =>
-          Some(Dependency(CodePath(sourceModule, sourceDir, simplifiedDependency.filepath), isCompileDependency = true))
+          Some(Dependency(analyze.CodePath(sourceModule, sourceDir, simplifiedDependency.filepath), isCompileDependency = true))
         }
       case None =>
         Right(None)

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/CompositeDependencyAnalyzer.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/CompositeDependencyAnalyzer.scala
@@ -1,4 +1,4 @@
-package com.wix.bazel.migrator.transform
+package com.wix.bazel.migrator.analyze
 
 import com.wix.bazel.migrator.model.SourceModule
 

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/ExceptionFormattingDependencyAnalyzer.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/ExceptionFormattingDependencyAnalyzer.scala
@@ -1,9 +1,10 @@
-package com.wix.bazel.migrator.transform
+package com.wix.bazel.migrator.analyze
 
 import com.fasterxml.jackson.annotation.{JsonIgnoreProperties, JsonTypeInfo}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.wix.bazel.migrator.model.SourceModule
+import com.wix.bazel.migrator.transform.failures.{AnalyzeException, AnalyzeFailure}
 
 class ExceptionFormattingDependencyAnalyzer(dependencyAnalyzer: DependencyAnalyzer) extends DependencyAnalyzer {
   private val om = new ObjectMapper().registerModule(DefaultScalaModule)

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/GeneratedCodeRegistry.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/GeneratedCodeRegistry.scala
@@ -1,4 +1,4 @@
-package com.wix.bazel.migrator.transform
+package com.wix.bazel.migrator.analyze
 
 import com.wix.bazel.migrator.overrides.{GeneratedCodeLink, GeneratedCodeLinksOverrides}
 

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/InternalFileDepsOverridesDependencyAnalyzer.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/InternalFileDepsOverridesDependencyAnalyzer.scala
@@ -2,7 +2,6 @@ package com.wix.bazel.migrator.analyze
 
 import java.nio.file.Path
 
-import com.wix.bazel.migrator.analyze
 import com.wix.bazel.migrator.model.SourceModule
 import com.wix.bazel.migrator.overrides.InternalFileDepsOverridesReader
 import com.wix.build.maven.analysis.SourceModules
@@ -57,7 +56,7 @@ class InternalFileDepsOverridesDependencyAnalyzer(sourceModules: SourceModules, 
   }
 
   private def dependencyOn(isCompileDependency: Boolean)(relativeFilePath: String): Dependency =
-    analyze.Dependency(codePathFrom(relativeFilePath), isCompileDependency)
+    Dependency(codePathFrom(relativeFilePath), isCompileDependency)
 
 
 }

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/InternalFileDepsOverridesDependencyAnalyzer.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/InternalFileDepsOverridesDependencyAnalyzer.scala
@@ -1,7 +1,8 @@
-package com.wix.bazel.migrator.transform
+package com.wix.bazel.migrator.analyze
 
 import java.nio.file.Path
 
+import com.wix.bazel.migrator.analyze
 import com.wix.bazel.migrator.model.SourceModule
 import com.wix.bazel.migrator.overrides.InternalFileDepsOverridesReader
 import com.wix.build.maven.analysis.SourceModules
@@ -56,7 +57,7 @@ class InternalFileDepsOverridesDependencyAnalyzer(sourceModules: SourceModules, 
   }
 
   private def dependencyOn(isCompileDependency: Boolean)(relativeFilePath: String): Dependency =
-    Dependency(codePathFrom(relativeFilePath), isCompileDependency)
+    analyze.Dependency(codePathFrom(relativeFilePath), isCompileDependency)
 
 
 }

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/ManualInfoDependencyAnalyzer.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/ManualInfoDependencyAnalyzer.scala
@@ -1,5 +1,6 @@
-package com.wix.bazel.migrator.transform
+package com.wix.bazel.migrator.analyze
 
+import com.wix.bazel.migrator.analyze
 import com.wix.bazel.migrator.model.SourceModule
 import com.wix.build.maven.analysis.SourceModules
 
@@ -321,5 +322,5 @@ class ManualInfoDependencyAnalyzer(sourceModules: SourceModules) extends Depende
   }
   
   private def dependencyOn(relativeFilePath: String): Dependency =
-    Dependency(codePathFrom(relativeFilePath),isCompileDependency = false)
+    analyze.Dependency(codePathFrom(relativeFilePath),isCompileDependency = false)
 }

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/ManualInfoDependencyAnalyzer.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/ManualInfoDependencyAnalyzer.scala
@@ -1,6 +1,5 @@
 package com.wix.bazel.migrator.analyze
 
-import com.wix.bazel.migrator.analyze
 import com.wix.bazel.migrator.model.SourceModule
 import com.wix.build.maven.analysis.SourceModules
 
@@ -322,5 +321,5 @@ class ManualInfoDependencyAnalyzer(sourceModules: SourceModules) extends Depende
   }
   
   private def dependencyOn(relativeFilePath: String): Dependency =
-    analyze.Dependency(codePathFrom(relativeFilePath),isCompileDependency = false)
+    Dependency(codePathFrom(relativeFilePath),isCompileDependency = false)
 }

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/RelativePathSupport.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/RelativePathSupport.scala
@@ -1,4 +1,4 @@
-package com.wix.bazel.migrator.transform
+package com.wix.bazel.migrator.analyze
 
 import java.io.IOException
 import java.nio.file.{Path, Paths}

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/SourceModuleSupport.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/SourceModuleSupport.scala
@@ -1,4 +1,4 @@
-package com.wix.bazel.migrator.transform
+package com.wix.bazel.migrator.analyze
 
 import java.io.IOException
 

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/ZincDependencyAnalyzer.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze/ZincDependencyAnalyzer.scala
@@ -1,4 +1,4 @@
-package com.wix.bazel.migrator.transform
+package com.wix.bazel.migrator.analyze
 
 import java.nio.file.{Path, Paths}
 

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/BUILD.bazel
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/BUILD.bazel
@@ -1,0 +1,27 @@
+package(default_visibility = ["//visibility:public"])
+
+sources()
+
+scala_library(
+    name = "app",
+    srcs = [
+        ":sources",
+    ],
+    deps = [
+        "//dependency-resolver/maven-dependency-resolver-api/src/main/scala/com/wixpress/build/maven",
+        "//dependency-resolver/maven-dependency-resolver/src/main/scala/com/wixpress/build/maven",
+        "//dependency-synchronizer/bazel-deps-synchronizer/src/main/scala/com/wixpress/build/bazel",
+        "//dependency-synchronizer/bazel-deps-synchronizer/src/main/scala/com/wixpress/build/sync",
+        "//migrator/bazel-migrator-model/src/main/java/com/wix/bazel/migrator/model",
+        "//migrator/wix-bazel-migrator/src/main/java/com/wix:agg=bazel/migrator_bazel/migrator/transform_build/maven/analysis",
+        "//migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze",
+        "//migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/external/registry",
+        "//migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/overrides",
+        "//migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/failures",
+        "//migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/utils",
+        "//repo-analyzer/maven-repo-analyzer/src/main/java/com/wix/build/maven/analysis",
+        "@com_codota_codota_sdk_java",
+        "@com_fasterxml_jackson_core_jackson_databind",
+        "@com_fasterxml_jackson_module_jackson_module_scala_2_12",
+    ],
+)

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/DebuggingUtilities.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/DebuggingUtilities.scala
@@ -1,4 +1,4 @@
-package com.wix.bazel.migrator
+package com.wix.bazel.migrator.app
 
 import java.io.{PrintWriter, StringWriter}
 import java.nio.file.{Files, Paths, StandardOpenOption}
@@ -7,10 +7,11 @@ import com.codota.service.client.SearchClient
 import com.codota.service.connector.{ApacheServiceConnector, ConnectorSettings}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.wix.bazel.migrator.analyze.CodotaDependencyAnalyzer._
+import com.wix.bazel.migrator.analyze.{AnalyzeFailureMixin, ExceptionFormattingDependencyAnalyzer, IgnoringMavenDependenciesMixin, ThrowableMixin}
 import com.wix.bazel.migrator.model.SourceModule
-import com.wix.bazel.migrator.transform.AnalyzeFailure.Composite
-import com.wix.bazel.migrator.transform.CodotaDependencyAnalyzer._
-import com.wix.bazel.migrator.transform._
+import com.wix.bazel.migrator.transform.failures.AnalyzeFailure.Composite
+import com.wix.bazel.migrator.transform.failures.{AnalyzeException, AnalyzeFailure}
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/Migrator.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/Migrator.scala
@@ -1,10 +1,12 @@
-package com.wix.bazel.migrator
+package com.wix.bazel.migrator.app
 
 import java.nio.file.Files
 
 import better.files.FileOps
 import com.wix.bazel.migrator.BazelRcManagedDevEnvWriter.defaultExodusOptions
 import com.wix.bazel.migrator.PreludeWriter._
+import com.wix.bazel.migrator._
+import com.wix.bazel.migrator.analyze._
 import com.wix.bazel.migrator.external.registry.{CachingEagerExternalSourceModuleRegistry, CodotaExternalSourceModuleRegistry, CompositeExternalSourceModuleRegistry, ConstantExternalSourceModuleRegistry}
 import com.wix.bazel.migrator.overrides.{AdditionalDepsByMavenDepsOverrides, AdditionalDepsByMavenDepsOverridesReader, MavenArchiveTargetsOverridesReader}
 import com.wix.bazel.migrator.transform._

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/MigratorApp.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/MigratorApp.scala
@@ -1,4 +1,6 @@
-package com.wix.bazel.migrator
+package com.wix.bazel.migrator.app
+
+import com.wix.bazel.migrator.RunConfiguration
 
 trait MigratorApp extends App {
   lazy val configuration = RunConfiguration.from(args)

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/MigratorApplication.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/MigratorApplication.scala
@@ -1,4 +1,4 @@
-package com.wix.bazel.migrator
+package com.wix.bazel.migrator.app
 
 import scala.io.Source
 

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/MigratorInputs.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/MigratorInputs.scala
@@ -1,14 +1,14 @@
-package com.wix.bazel.migrator
+package com.wix.bazel.migrator.app
 
 import java.io
 import java.net.URL
-import java.nio.file.{Files, Path}
+import java.nio.file.Path
 import java.time.temporal.ChronoUnit
 
-import better.files.File
+import com.wix.bazel.migrator.analyze.{CodotaDependencyAnalyzer, ZincDepednencyAnalyzer}
 import com.wix.bazel.migrator.model.SourceModule
-import com.wix.bazel.migrator.transform.{CodotaDependencyAnalyzer, ZincDepednencyAnalyzer}
 import com.wix.bazel.migrator.utils.DependenciesDifferentiator
+import com.wix.bazel.migrator.{HighestVersionProvidedScopeConflictResolution, Persister, RunConfiguration}
 import com.wix.build.maven.analysis._
 import com.wixpress.build.bazel.workspaces.WorkspaceName
 import com.wixpress.build.maven

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/Writer.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/Writer.scala
@@ -1,7 +1,8 @@
-package com.wix.bazel.migrator
+package com.wix.bazel.migrator.app
 
 import java.nio.file.{Files, Path, StandardOpenOption}
 
+import com.wix.bazel.migrator._
 import com.wix.bazel.migrator.model.CodePurpose.{Prod, Test}
 import com.wix.bazel.migrator.model.Target._
 import com.wix.bazel.migrator.model.{CodePurpose, Package, Scope, SourceModule, Target, TestType}

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/failures/BUILD.bazel
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/failures/BUILD.bazel
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+sources()
+scala_library(
+    name = "failures",
+    srcs = [
+        ":sources",
+    ],
+    deps = [
+        "@com_codota_codota_sdk_java",
+        "//migrator/bazel-migrator-model/src/main/java/com/wix/bazel/migrator/model:model"
+    ]
+)

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/failures/Failures.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/failures/Failures.scala
@@ -1,4 +1,4 @@
-package com.wix.bazel.migrator.transform
+package com.wix.bazel.migrator.transform.failures
 
 import com.codota.service.model.DependencyInfo
 import com.wix.bazel.migrator.model.SourceModule

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/utils/BUILD.bazel
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/utils/BUILD.bazel
@@ -11,6 +11,7 @@ scala_library(
         "//migrator/wix-bazel-migrator:main_dependencies",
         "//models/maven-model/src/main/scala/com/wixpress/build/maven",
         "@com_fasterxml_jackson_core_jackson_annotations",
+        "//migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/failures:failures",
     ],
 )
 

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/utils/Retry.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/utils/Retry.scala
@@ -1,6 +1,6 @@
-package com.wix.bazel.migrator
+package com.wix.bazel.migrator.utils
 
-import com.wix.bazel.migrator.transform.AnalyzeFailure
+import com.wix.bazel.migrator.transform.failures.AnalyzeFailure
 
 import scala.util.{Failure, Success}
 

--- a/migrator/wix-bazel-migrator/src/test/scala/com/wix/bazel/migrator/transform/BUILD.bazel
+++ b/migrator/wix-bazel-migrator/src/test/scala/com/wix/bazel/migrator/transform/BUILD.bazel
@@ -18,6 +18,7 @@ specs2_unit_test(
         "//migrator/bazel-migrator-model/src/main/java/com/wix/bazel/migrator/model",
         "//migrator/wix-bazel-migrator:tests_dependencies",
         "//migrator/wix-bazel-migrator/src/main/java/com/wix:agg=bazel/migrator_bazel/migrator/transform_build/maven/analysis",
+        "//migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze",
         "//migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/external/registry",
         "//migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/overrides",
         "//migrator/wix-bazel-migrator/src/test/scala/com/wix/bazel/migrator/external/registry",

--- a/migrator/wix-bazel-migrator/src/test/scala/com/wix/bazel/migrator/transform/GeneratedCodeRegistryTest.scala
+++ b/migrator/wix-bazel-migrator/src/test/scala/com/wix/bazel/migrator/transform/GeneratedCodeRegistryTest.scala
@@ -1,5 +1,6 @@
 package com.wix.bazel.migrator.transform
 
+import com.wix.bazel.migrator.analyze.GeneratedCodeRegistry
 import com.wix.bazel.migrator.overrides.{GeneratedCodeLink, GeneratedCodeLinksOverrides}
 import com.wixpress.build.maven.MavenMakers
 import org.specs2.matcher.Scope


### PR DESCRIPTION
Trying to untangle the major uber target: `//migrator/wix-bazel-migrator/src/main/java/com/wix:agg=bazel/migrator_bazel/migrator/transform_build/maven/analysis`

This is only part1.

I think in the future we would want to remove unused deps, and break furthermore. Also - I didn't change dependencies of test targets yet.