### PR TITLE
[WIP] Migrator v2

### DIFF
--- a/migrator/bazel-migrator-model/src/main/java/com/wix/bazel/migrator/model/Module.scala
+++ b/migrator/bazel-migrator-model/src/main/java/com/wix/bazel/migrator/model/Module.scala
@@ -2,6 +2,11 @@ package com.wix.bazel.migrator.model
 
 import com.wixpress.build.maven.{Coordinates, Dependency}
 
+case class SourceModuleWithoutDeps(relativePathFromMonoRepoRoot: String,
+                        coordinates: Coordinates,
+                        resourcesPaths: Set[String] = Set.empty,
+                       )
+
 case class SourceModule(relativePathFromMonoRepoRoot: String,
                         coordinates: Coordinates,
                         resourcesPaths: Set[String] = Set.empty,
@@ -9,7 +14,8 @@ case class SourceModule(relativePathFromMonoRepoRoot: String,
                        )
 
 case class ModuleDependencies(directDependencies: Set[Dependency] = Set.empty,
-                              allDependencies: Set[Dependency] = Set.empty)
+                              allDependencies: Set[Dependency] = Set.empty,
+                              managedDependencies: Set[Dependency] = Set.empty)
 
 //Omits version since source dependency
 //Omits packaging and classifier since they are very hard to generalize

--- a/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/BUILD.bazel
+++ b/migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform/BUILD.bazel
@@ -11,9 +11,9 @@ scala_library(
         "//dependency-resolver/maven-dependency-resolver-api/src/main/scala/com/wixpress/build/maven",
         "//migrator/bazel-migrator:main_dependencies",
         "//migrator/bazel-migrator-model/src/main/java/com/wix/bazel/migrator/model",
+        "//migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze",
         "//models/maven-model/src/main/scala/com/wixpress/build/maven",
         "@org_jgrapht_jgrapht_core",
-        "//migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze:analyze",
     ],
 )
 

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/BUILD.bazel
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/BUILD.bazel
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+sources()
+
+scala_library(
+    name = "v2",
+    srcs = [":sources"],
+    deps = [
+        "//migrator/bazel-migrator-model/src/main/java/com/wix/bazel/migrator/model",
+        "//migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/analyze",
+        "//migrator/bazel-migrator/src/main/java/com/wix/bazel/migrator/transform",
+    ],
+)

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/BuildFilesBuilder.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/BuildFilesBuilder.scala
@@ -1,0 +1,10 @@
+package com.wix.bazel.migrator.app.v2
+
+import com.wix.bazel.migrator.model
+
+/**
+ * Takes bazel packages and transforms it into a build file content
+ */
+trait BuildFilesBuilder {
+  def extractBuildFile(bazelPackage: model.Package): FileToWrite
+}

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/ExternalDepsExtractor.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/ExternalDepsExtractor.scala
@@ -1,0 +1,12 @@
+package com.wix.bazel.migrator.app.v2
+
+import com.wix.bazel.migrator.model.{ModuleDependencies, SourceModule}
+
+/**
+ * Extracts external dependencies from repo modules, transforms them into a single object of module dependencies
+ * That includes: direct deps, all deps and managed deps
+ * Consider side effect / additional return of report of collisions durin the reduction operation
+ */
+trait ExternalDepsExtractor {
+  def collectAndConsolidateExternalDeps(modules: Set[SourceModule]): ModuleDependencies
+}

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/ExternalDepsLoader.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/ExternalDepsLoader.scala
@@ -1,0 +1,13 @@
+package com.wix.bazel.migrator.app.v2
+
+import com.wix.bazel.migrator.model.ModuleDependencies
+
+/**
+ * Translate the external dependencies that were found into loader functions (bzl files)
+ * Dictates what needs to be written to WORKSPACE file in order to load those rules
+ */
+trait ExternalDepsLoader {
+  def workspacePart: String
+
+  def externalDepsLoadersOf(repoExternalDependencies: ModuleDependencies): Set[FileToWrite]
+}

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/FilesWriter.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/FilesWriter.scala
@@ -1,0 +1,10 @@
+package com.wix.bazel.migrator.app.v2
+
+/**
+ * Actually writes stuff to disk
+ */
+trait FilesWriter {
+  def appendToWorkspaceFile(content:String): Unit
+  def appendToFile(fileToWrite: FileToWrite): Unit
+}
+case class FileToWrite(relativePathToFile: String, content: String)

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/MavenModuleDiscovery.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/MavenModuleDiscovery.scala
@@ -1,0 +1,10 @@
+package com.wix.bazel.migrator.app.v2
+
+import com.wix.bazel.migrator.model.SourceModuleWithoutDeps
+
+/**
+ * Discovers repo modules without resolving the deps of them
+ */
+trait MavenModuleDiscovery {
+  def findModules(): Set[SourceModuleWithoutDeps]
+}

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/MigratorV2.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/MigratorV2.scala
@@ -1,0 +1,54 @@
+package com.wix.bazel.migrator.app.v2
+
+import com.wix.bazel.migrator.analyze.{Code, DependencyAnalyzer}
+import com.wix.bazel.migrator.model
+import com.wix.bazel.migrator.model.{SourceModule, SourceModuleWithoutDeps}
+import com.wix.bazel.migrator.transform.CodeAnalysisTransformer
+
+
+object MigratorV2 {
+  type CodeModules = Map[SourceModule, List[Code]]
+
+  // all of those members should be instantiated using the run config at the beginning of the run
+  val dependencyAnalyzer: DependencyAnalyzer = ???
+  val modulesDiscovery: MavenModuleDiscovery = ???
+  val modulesDepsDiscovery: ModulesDepsDiscovery = ???
+  val externalDepsExtractor: ExternalDepsExtractor = ???
+  val externalDepsLoader: ExternalDepsLoader = ???
+  val filesWriter: FilesWriter = ???
+  val buildFilesBuilder: BuildFilesBuilder = ???
+  val staticFiles: StaticFiles = ???
+
+  def main(args: Array[String]): Unit = {
+    // Step 0: find modules with deps
+    val modulesWithDeps: Set[SourceModule] = findModulesWithDeps
+
+    // Step 1 : write bazel packages (depends on thread0)
+    val codeModules: CodeModules = modulesWithDeps.map(m => m -> dependencyAnalyzer.allCodeForModule(m)).toMap
+    val bazelPackages: Set[model.Package] = transformer(codeModules).transform(modulesWithDeps)
+    bazelPackages.foreach(writeBuildFile)
+
+    // Step 2 : write bazel deps (depends thread 0)
+    val consolidatedDeps = externalDepsExtractor.collectAndConsolidateExternalDeps(modulesWithDeps)
+    externalDepsLoader.externalDepsLoadersOf(consolidatedDeps).foreach(filesWriter.appendToFile)
+
+    // Step 3 : Static files (don't depend on anything)
+    filesWriter.appendToWorkspaceFile(staticFiles.workspaceFileHeader)
+    filesWriter.appendToWorkspaceFile(externalDepsLoader.workspacePart)
+    staticFiles.otherFiles.foreach(filesWriter.appendToFile)
+    filesWriter.appendToWorkspaceFile(staticFiles.worksapceFileFooter)
+  }
+
+  private def writeBuildFile(babelPackage: model.Package): Unit = {
+    filesWriter.appendToFile(buildFilesBuilder.extractBuildFile(babelPackage))
+  }
+
+  private def findModulesWithDeps = {
+    val modules: Set[SourceModuleWithoutDeps] = modulesDiscovery.findModules()
+    val modulesWithDeps: Set[SourceModule] = modules.map(modulesDepsDiscovery.findModuleDeps)
+    modulesWithDeps
+  }
+
+  // workaround since CodeAnalysisTransformer requires DependencyAnalyzer instance
+  private def transformer(codeModules: CodeModules) = new CodeAnalysisTransformer((module: SourceModule) => codeModules(module))
+}

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/MigratorV2.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/MigratorV2.scala
@@ -1,25 +1,21 @@
 package com.wix.bazel.migrator.app.v2
 
 import com.wix.bazel.migrator.analyze.{Code, DependencyAnalyzer}
+import com.wix.bazel.migrator.app.v2.MigratorV2.CodeModules
 import com.wix.bazel.migrator.model
 import com.wix.bazel.migrator.model.{SourceModule, SourceModuleWithoutDeps}
 import com.wix.bazel.migrator.transform.CodeAnalysisTransformer
 
+class MigratorV2(modulesDiscovery: MavenModuleDiscovery,
+                 modulesDepsDiscovery: ModulesDepsDiscovery,
+                 dependencyAnalyzer: DependencyAnalyzer,
+                 externalDepsExtractor: ExternalDepsExtractor,
+                 externalDepsLoader: ExternalDepsLoader,
+                 buildFilesBuilder: BuildFilesBuilder,
+                 staticFiles: StaticFiles,
+                 filesWriter: FilesWriter) {
 
-object MigratorV2 {
-  type CodeModules = Map[SourceModule, List[Code]]
-
-  // all of those members should be instantiated using the run config at the beginning of the run
-  val dependencyAnalyzer: DependencyAnalyzer = ???
-  val modulesDiscovery: MavenModuleDiscovery = ???
-  val modulesDepsDiscovery: ModulesDepsDiscovery = ???
-  val externalDepsExtractor: ExternalDepsExtractor = ???
-  val externalDepsLoader: ExternalDepsLoader = ???
-  val filesWriter: FilesWriter = ???
-  val buildFilesBuilder: BuildFilesBuilder = ???
-  val staticFiles: StaticFiles = ???
-
-  def main(args: Array[String]): Unit = {
+  def migrate(): Unit = {
     // Step 0: find modules with deps
     val modulesWithDeps: Set[SourceModule] = findModulesWithDeps
 
@@ -37,6 +33,7 @@ object MigratorV2 {
     filesWriter.appendToWorkspaceFile(externalDepsLoader.workspacePart)
     staticFiles.otherFiles.foreach(filesWriter.appendToFile)
     filesWriter.appendToWorkspaceFile(staticFiles.worksapceFileFooter)
+
   }
 
   private def writeBuildFile(babelPackage: model.Package): Unit = {
@@ -51,4 +48,32 @@ object MigratorV2 {
 
   // workaround since CodeAnalysisTransformer requires DependencyAnalyzer instance
   private def transformer(codeModules: CodeModules) = new CodeAnalysisTransformer((module: SourceModule) => codeModules(module))
+
+}
+
+object MigratorV2 {
+  type CodeModules = Map[SourceModule, List[Code]]
+
+  // all of those members should be instantiated using the run config at the beginning of the run
+  val modulesDiscovery: MavenModuleDiscovery = ???
+  val modulesDepsDiscovery: ModulesDepsDiscovery = ???
+  val dependencyAnalyzer: DependencyAnalyzer = ???
+  val externalDepsExtractor: ExternalDepsExtractor = ???
+  val externalDepsLoader: ExternalDepsLoader = ???
+  val filesWriter: FilesWriter = ???
+  val buildFilesBuilder: BuildFilesBuilder = ???
+  val staticFiles: StaticFiles = ???
+
+  def main(args: Array[String]): Unit = {
+    val migrator = new MigratorV2(modulesDiscovery,
+      modulesDepsDiscovery,
+      dependencyAnalyzer,
+      externalDepsExtractor,
+      externalDepsLoader,
+      buildFilesBuilder,
+      staticFiles,
+      filesWriter)
+
+    migrator.migrate()
+  }
 }

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/ModulesDepsDiscovery.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/ModulesDepsDiscovery.scala
@@ -1,0 +1,10 @@
+package com.wix.bazel.migrator.app.v2
+
+import com.wix.bazel.migrator.model.{SourceModule, SourceModuleWithoutDeps}
+
+/**
+ * Finds deps of given module: direct deps, all deps and managed deps.
+ */
+trait ModulesDepsDiscovery {
+  def findModuleDeps(sourceModule: SourceModuleWithoutDeps): SourceModule
+}

--- a/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/StaticFiles.scala
+++ b/migrator/wix-bazel-migrator/src/main/java/com/wix/bazel/migrator/app/v2/StaticFiles.scala
@@ -1,0 +1,13 @@
+package com.wix.bazel.migrator.app.v2
+
+/**
+ * Provides the static content of files that should be written in any case.
+ * One way to implement it is to give a path to static "template" folder + list of key-value to replace in files.
+ */
+trait StaticFiles {
+  def workspaceFileHeader: String
+
+  def worksapceFileFooter: String
+
+  def otherFiles: Set[FileToWrite]
+}


### PR DESCRIPTION
Suggested simplified version of migrator app that will allow external contributors to better understand the mechanism of migrator.

Right now - we have `MigratorInput` class that has many members that are instantiated as we instantiate the class which makes it very hard to track and change.

I've managed to identify several building blocks and created traits to describe them. 

I think the next steps are:
- [ ] Agree on this structure
- [ ] Adjust our current solution to work with those traits, add tests / integration tests where it's possible.
- [ ] Read configuration from RunConfiguration and instantiate collaborators as needed.

Still probably missing solution for resources packages, and main_dependencies. Need to iterate over all the special writings we do at the end of migration